### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/cloud/vra_service.rb
+++ b/lib/chef/knife/cloud/vra_service.rb
@@ -21,7 +21,7 @@
 require "chef/knife/cloud/exceptions"
 require "chef/knife/cloud/service"
 require "chef/knife/cloud/helpers"
-require "chef/knife/cloud/vra_service_helpers"
+require_relative "vra_service_helpers"
 require "vra"
 
 class Chef

--- a/lib/chef/knife/vra_catalog_list.rb
+++ b/lib/chef/knife/vra_catalog_list.rb
@@ -20,9 +20,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/vra_service"
-require "chef/knife/cloud/vra_service_helpers"
-require "chef/knife/cloud/vra_service_options"
+require_relative "cloud/vra_service"
+require_relative "cloud/vra_service_helpers"
+require_relative "cloud/vra_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/vra_server_create.rb
+++ b/lib/chef/knife/vra_server_create.rb
@@ -21,9 +21,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/create_command"
 require "chef/knife/cloud/server/create_options"
-require "chef/knife/cloud/vra_service"
-require "chef/knife/cloud/vra_service_helpers"
-require "chef/knife/cloud/vra_service_options"
+require_relative "cloud/vra_service"
+require_relative "cloud/vra_service_helpers"
+require_relative "cloud/vra_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/vra_server_delete.rb
+++ b/lib/chef/knife/vra_server_delete.rb
@@ -21,9 +21,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/delete_options"
 require "chef/knife/cloud/server/delete_command"
-require "chef/knife/cloud/vra_service"
-require "chef/knife/cloud/vra_service_helpers"
-require "chef/knife/cloud/vra_service_options"
+require_relative "cloud/vra_service"
+require_relative "cloud/vra_service_helpers"
+require_relative "cloud/vra_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/vra_server_list.rb
+++ b/lib/chef/knife/vra_server_list.rb
@@ -21,9 +21,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/list_command"
 require "chef/knife/cloud/server/list_options"
-require "chef/knife/cloud/vra_service"
-require "chef/knife/cloud/vra_service_helpers"
-require "chef/knife/cloud/vra_service_options"
+require_relative "cloud/vra_service"
+require_relative "cloud/vra_service_helpers"
+require_relative "cloud/vra_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/vra_server_show.rb
+++ b/lib/chef/knife/vra_server_show.rb
@@ -21,9 +21,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/show_options"
 require "chef/knife/cloud/server/show_command"
-require "chef/knife/cloud/vra_service"
-require "chef/knife/cloud/vra_service_helpers"
-require "chef/knife/cloud/vra_service_options"
+require_relative "cloud/vra_service"
+require_relative "cloud/vra_service_helpers"
+require_relative "cloud/vra_service_options"
 
 class Chef
   class Knife


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>