### PR TITLE
INFCT-76 Updated the vmware-vra gem dependency and added support for Ruby 3.0 and 3.1

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,13 +10,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
 - label: run-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake
@@ -24,3 +17,19 @@ steps:
     executor:
       docker:
         image: ruby:2.7-buster
+
+- label: run-specs-ruby-3.0
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0-buster
+
+- label: run-specs-ruby-3.1
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1-buster

--- a/knife-vrealize.gemspec
+++ b/knife-vrealize.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*"] + %w{LICENSE}
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
+  spec.add_dependency "knife"
   spec.add_dependency "knife-cloud",  ">= 1.2.0", "< 5.0"
   spec.add_dependency "vmware-vra",   "~> 2", "< 3" # 3 and above is not supported for this version of vRA
   spec.add_dependency "vcoworkflows", "~> 0.2"

--- a/knife-vrealize.gemspec
+++ b/knife-vrealize.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "knife-cloud",  ">= 1.2.0", "< 5.0"
-  spec.add_dependency "vmware-vra",   "~> 2"
+  spec.add_dependency "vmware-vra",   "~> 2", "< 3" # 3 and above is not support for this version of vRA
   spec.add_dependency "vcoworkflows", "~> 0.2"
   spec.add_dependency "rb-readline", "~> 0.5"
 end

--- a/knife-vrealize.gemspec
+++ b/knife-vrealize.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "knife-cloud",  ">= 1.2.0", "< 5.0"
-  spec.add_dependency "vmware-vra",   "~> 2", "< 3" # 3 and above is not support for this version of vRA
+  spec.add_dependency "vmware-vra",   "~> 2", "< 3" # 3 and above is not supported for this version of vRA
   spec.add_dependency "vcoworkflows", "~> 0.2"
   spec.add_dependency "rb-readline", "~> 0.5"
 end


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Version 3 and above of the vmware-vra gem requires the vRA 8.x. This version currently supports version 7.x. This PR is to update the dependency. Support for 8.x will be added in a separate PR.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
