### PR TITLE
CHEF-1918 Fixed the knife-vrealize verify test failure

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,22 +10,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7-buster
-
-- label: run-specs-ruby-3.0
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0-buster
-
 - label: run-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/knife-vrealize.gemspec
+++ b/knife-vrealize.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*"] + %w{LICENSE}
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_dependency "knife"
   spec.add_dependency "knife-cloud",  ">= 1.2.0", "< 5.0"


### PR DESCRIPTION

## Description
updated ruby version to 3.1 and removed 2.7 and 3.0 ruby verify pipeline as the latest chef 18.2.7 supports ruby >= 3.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
